### PR TITLE
Correções Componente PessoaCadastro e dependentes

### DIFF
--- a/frontend/src/components/pessoas/AlunoForm.vue
+++ b/frontend/src/components/pessoas/AlunoForm.vue
@@ -189,9 +189,6 @@ export default {
     created() {
         console.log("created")
         this.update('turma.curso.codigo', this.local.turma.curso.codigo)
-    },
-    mounted() {
-        console.log("mounted")
         this.fillOptionsCursos()
         this.fillOptionsTurmas()
         this.fillOptionsSituacoesTurma()

--- a/frontend/src/components/pessoas/ColaboradorForm.vue
+++ b/frontend/src/components/pessoas/ColaboradorForm.vue
@@ -52,9 +52,6 @@ export default {
     created() {
         console.log("created")
         this.update('competencia.codigo', this.local.competencia.codigo)
-    },
-    mounted() {
-        console.log("mounted")
         this.fillOptionsCompetenciasColaborador()
     },
     watch: {

--- a/frontend/src/components/pessoas/InterpreteForm.vue
+++ b/frontend/src/components/pessoas/InterpreteForm.vue
@@ -75,9 +75,6 @@ export default {
     created() {
         console.log("created")
         this.update('situacao.codigo', this.local.situacao.codigo)
-    },
-    mounted() {
-        console.log("mounted")
         this.fillOptionsSituacoesInterprete()
     },
     watch: {

--- a/frontend/src/components/pessoas/PessoaCadastro.vue
+++ b/frontend/src/components/pessoas/PessoaCadastro.vue
@@ -836,10 +836,9 @@ export default {
                             }
                             break
                         case PAPEL.INTERPRETE:
-                            console.log('aqui')
-                            if (!this.pessoa.interprete && Object.keys(this.interprete).length > 0) {
+                            if (!this.pessoa.interprete) {
                                 // Reaproveita os dados do intérprete previamente cadastrados
-                                if (this.interprete) {
+                                if (this.interprete  && Object.keys(this.interprete).length > 0) {
                                     this.$set(this.pessoa, 'interprete', this.interprete)
                                 } else {
                                     this.$set(this.pessoa, 'interprete', null)


### PR DESCRIPTION
Código para carga das opções dos combos movido do hook mounted para created, para corrigir o problema de combos vazios. Também foi corrigido a seleção do papel Intérprete.